### PR TITLE
Set Flask version to lower than 2.3

### DIFF
--- a/windows/requirements.txt
+++ b/windows/requirements.txt
@@ -1,6 +1,6 @@
 #jcconv
 simplejson
-Flask
+Flask<2.3
 Flask-Babel
 Flask-cors
 #pyusb # Only useful to make escpos work via usb (easier via win32raw)


### PR DESCRIPTION
`before_first_request` decorator is used here:
https://github.com/pywebdriver/pywebdriver/blob/e1821e8df02d319b46dfdcdeeccf12d047092d18/pywebdriver/plugins/scale_driver.py#L142 but has been removed in Flask 2.3 so we need a Flask version lower than 2.3.